### PR TITLE
added mapping for different environments

### DIFF
--- a/Jenkinsfile.xml
+++ b/Jenkinsfile.xml
@@ -19,6 +19,6 @@
   </highlighting>
   <extensionMap>
     <mapping pattern="Jenkinsfile" />
-    <mapping pattern="Jenkinsfile.*" />
+    <mapping pattern="Jenkinsfile*" />
   </extensionMap>
 </filetype>

--- a/Jenkinsfile.xml
+++ b/Jenkinsfile.xml
@@ -19,5 +19,6 @@
   </highlighting>
   <extensionMap>
     <mapping pattern="Jenkinsfile" />
+    <mapping pattern="Jenkinsfile.*" />
   </extensionMap>
 </filetype>


### PR DESCRIPTION
I believe many people use this approach when naming their jenkinsfiles, for example:
`Jenkinsfile.staging`, `Jenkinsfile.dockerDeployment`, etc.
